### PR TITLE
Add open mcp marketplace api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,25 @@ uv --directory /path/to/alibabacloud-adb-mysql-mcp-server run adb-mysql-mcp-serv
 - ### Prompts
 
 Not provided at the present moment.
+
+
+## Resources 
+
+### Open MCP Marketplace API Support 
+![MCP Marketplace User Review Rating Badge](http://www.deepnlp.org/api/marketplace/svg?aliyun/alibabacloud-adb-mysql-mcp-server)|[GitHub](https://github.com/AI-Agent-Hub/mcp-marketplace)|[Doc](http://www.deepnlp.org/doc/mcp_marketplace)|[MCP Marketplace](http://www.deepnlp.org/store/ai-agent/mcp-server)
+- Allow AI App/Agent/LLM to find this MCP Server via common python/typescript API, search and explore relevant servers and tools
+
+***Example: Search Server and Tools***
+```python
+    import anthropic
+    import mcp_marketplace as mcpm
+
+    result_q = mcpm.search(query="alibabacloud adb mysql mcp server", mode="list", page_id=0, count_per_page=100, config_name="deepnlp") # search server by category choose various endpoint
+    result_id = mcpm.search(id="aliyun/alibabacloud-adb-mysql-mcp-server", mode="list", page_id=0, count_per_page=100, config_name="deepnlp")      # search server by id choose various endpoint 
+    tools = mcpm.list_tools(id="aliyun/alibabacloud-adb-mysql-mcp-server", config_name="deepnlp_tool")
+
+    # Call Claude to Choose Tools Function Calls 
+    client = anthropic.Anthropic()
+    response = client.messages.create(model="claude-3-7-sonnet-20250219", max_tokens=1024, tools=tools, messages=[])
+```
+


### PR DESCRIPTION
Hi, I would like to introduce MCP Marketplace Python and Typescript API and add support to your MCP Server, which allow any LLM AI Agent to integrate your MCP servers easily into the workflow, by searching relevant servers and tools meta and schemas, and give LLM more chances to know more about your MCP tools, increase usage from thousands of AI Agents or Applications. And here is a demo backend codes in python to integrate your servers tools for Claude function calls API...

## Resources 

### Open MCP Marketplace API Support 
![MCP Marketplace User Review Rating Badge](http://www.deepnlp.org/api/marketplace/svg?aliyun/alibabacloud-adb-mysql-mcp-server)|[GitHub](https://github.com/AI-Agent-Hub/mcp-marketplace)|[Doc](http://www.deepnlp.org/doc/mcp_marketplace)|[MCP Marketplace](http://www.deepnlp.org/store/ai-agent/mcp-server)
Allow AI App/Agent/LLM to find this MCP Server via common python/typescript API, search and explore relevant servers and tools

***Example: Search Server and Tools***
```python
    import anthropic
    import mcp_marketplace as mcpm

    result_q = mcpm.search(query="alibabacloud adb mysql mcp server", mode="list", page_id=0, count_per_page=100, config_name="deepnlp") # search server by category choose various endpoint
    result_id = mcpm.search(id="aliyun/alibabacloud-adb-mysql-mcp-server", mode="list", page_id=0, count_per_page=100, config_name="deepnlp")      # search server by id choose various endpoint 
    tools = mcpm.list_tools(id="aliyun/alibabacloud-adb-mysql-mcp-server", config_name="deepnlp_tool")

    # Call Claude to Choose Tools Function Calls 
    client = anthropic.Anthropic()
    response = client.messages.create(model="claude-3-7-sonnet-20250219", max_tokens=1024, tools=tools, messages=[])
```
 